### PR TITLE
feat: 音楽に反応するオーディオビジュアライザーを実装

### DIFF
--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -12,8 +12,25 @@ class AudioLoopPlayer {
     this.loopEnd = 0;
     this.duration = 0;
     
+    // Waveform properties
+    this.waveformCanvas = null;
+    this.waveformCtx = null;
+    this.waveformData = null;
+    this.waveformPlayhead = null;
+    this.waveformLoopRegion = null;
+    
+    // Visualizer properties
+    this.visualizerCanvas = null;
+    this.visualizerCtx = null;
+    this.analyserNode = null;
+    this.animationId = null;
+    this.particles = [];
+    this.frequencyData = null;
+    this.bufferLength = 0;
+    
     this.initializeElements();
     this.initializeEventListeners();
+    this.initializeVisualizer();
   }
 
   initializeElements() {
@@ -50,6 +67,12 @@ class AudioLoopPlayer {
     // Error elements
     this.errorToast = document.getElementById('errorToast');
     this.errorMessage = document.getElementById('errorMessage');
+    
+    // Waveform elements
+    this.waveformCanvas = document.getElementById('waveformCanvas');
+    this.waveformCtx = this.waveformCanvas ? this.waveformCanvas.getContext('2d') : null;
+    this.waveformPlayhead = document.getElementById('waveformPlayhead');
+    this.waveformLoopRegion = document.getElementById('waveformLoopRegion');
   }
 
   initializeEventListeners() {
@@ -75,6 +98,12 @@ class AudioLoopPlayer {
     // Loop controls
     this.loopResetBtn.addEventListener('click', () => this.resetLoop());
     
+    // Waveform controls
+    if (this.waveformCanvas) {
+      this.waveformCanvas.addEventListener('click', (e) => this.handleWaveformClick(e));
+      window.addEventListener('resize', () => this.resizeWaveform());
+    }
+    
     // Keyboard shortcuts
     document.addEventListener('keydown', (e) => this.handleKeyboard(e));
   }
@@ -83,7 +112,17 @@ class AudioLoopPlayer {
     if (!this.audioContext) {
       this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
       this.gainNode = this.audioContext.createGain();
-      this.gainNode.connect(this.audioContext.destination);
+      
+      // Create analyser node for visualizer
+      this.analyserNode = this.audioContext.createAnalyser();
+      this.analyserNode.fftSize = 256;
+      this.bufferLength = this.analyserNode.frequencyBinCount;
+      this.frequencyData = new Uint8Array(this.bufferLength);
+      
+      // Connect nodes: source -> gain -> analyser -> destination
+      this.gainNode.connect(this.analyserNode);
+      this.analyserNode.connect(this.audioContext.destination);
+      
       this.setVolume(this.volumeSlider.value / 100);
     }
   }
@@ -132,6 +171,7 @@ class AudioLoopPlayer {
       this.duration = this.audioBuffer.duration;
       
       this.setupPlayer();
+      this.generateWaveform();
     } catch (error) {
       this.showError('ファイルの読み込みに失敗しました: ' + error.message);
       this.clearFile();
@@ -141,6 +181,9 @@ class AudioLoopPlayer {
   setupPlayer() {
     this.playerSection.hidden = false;
     this.durationEl.textContent = this.formatTime(this.duration);
+    
+    // Initialize waveform canvas
+    this.resizeWaveform();
     
     // Initialize loop slider
     if (this.loopSlider.noUiSlider) {
@@ -175,6 +218,8 @@ class AudioLoopPlayer {
         this.sourceNode.loopStart = this.loopStart;
         this.sourceNode.loopEnd = this.loopEnd;
       }
+      
+      this.updateLoopRegion();
     });
     
     // Reset loop bounds
@@ -221,6 +266,9 @@ class AudioLoopPlayer {
     this.isPlaying = true;
     this.playIcon.hidden = true;
     this.pauseIcon.hidden = false;
+    
+    // Start visualizer
+    this.startVisualizer();
   }
 
   pause() {
@@ -233,6 +281,9 @@ class AudioLoopPlayer {
     this.isPlaying = false;
     this.playIcon.hidden = false;
     this.pauseIcon.hidden = true;
+    
+    // Stop visualizer
+    this.stopVisualizer();
   }
 
   stop() {
@@ -246,6 +297,9 @@ class AudioLoopPlayer {
     this.startTime = 0;
     this.playIcon.hidden = false;
     this.pauseIcon.hidden = true;
+    
+    // Stop visualizer
+    this.stopVisualizer();
   }
 
   handleSeek(e) {
@@ -268,6 +322,16 @@ class AudioLoopPlayer {
       const currentTime = (this.audioContext.currentTime - this.startTime) % this.duration;
       this.currentTimeEl.textContent = this.formatTime(currentTime);
       this.progressFill.style.width = (currentTime / this.duration * 100) + '%';
+      
+      // Update waveform playhead
+      if (this.waveformPlayhead && this.waveformCanvas) {
+        const width = this.waveformCanvas.getBoundingClientRect().width;
+        const position = (currentTime / this.duration) * width;
+        this.waveformPlayhead.style.left = position + 'px';
+        this.waveformPlayhead.classList.add('active');
+      }
+    } else if (this.waveformPlayhead) {
+      this.waveformPlayhead.classList.remove('active');
     }
     
     requestAnimationFrame(() => this.updateProgress());
@@ -351,6 +415,249 @@ class AudioLoopPlayer {
     setTimeout(() => {
       this.errorToast.hidden = true;
     }, 5000);
+  }
+
+  // Waveform visualization methods
+  generateWaveform() {
+    if (!this.audioBuffer || !this.waveformCanvas) return;
+    
+    const channelData = this.audioBuffer.getChannelData(0);
+    const samples = this.waveformCanvas.width;
+    const blockSize = Math.floor(channelData.length / samples);
+    const filteredData = [];
+    
+    for (let i = 0; i < samples; i++) {
+      const blockStart = blockSize * i;
+      let sum = 0;
+      for (let j = 0; j < blockSize; j++) {
+        sum += Math.abs(channelData[blockStart + j]);
+      }
+      filteredData.push(sum / blockSize);
+    }
+    
+    // Normalize
+    const max = Math.max(...filteredData);
+    this.waveformData = filteredData.map(n => n / max);
+    
+    this.drawWaveform();
+    this.updateLoopRegion();
+  }
+
+  drawWaveform() {
+    if (!this.waveformCtx || !this.waveformData) return;
+    
+    const width = this.waveformCanvas.width;
+    const height = this.waveformCanvas.height;
+    const halfHeight = height / 2;
+    
+    // Clear canvas
+    this.waveformCtx.clearRect(0, 0, width, height);
+    
+    // Draw waveform
+    this.waveformCtx.beginPath();
+    this.waveformCtx.strokeStyle = 'rgba(255, 255, 255, 0.7)';
+    this.waveformCtx.lineWidth = 1;
+    
+    for (let i = 0; i < this.waveformData.length; i++) {
+      const x = i;
+      const y = halfHeight - (this.waveformData[i] * halfHeight * 0.8);
+      
+      if (i === 0) {
+        this.waveformCtx.moveTo(x, halfHeight);
+      }
+      
+      this.waveformCtx.lineTo(x, y);
+    }
+    
+    // Mirror bottom half
+    for (let i = this.waveformData.length - 1; i >= 0; i--) {
+      const x = i;
+      const y = halfHeight + (this.waveformData[i] * halfHeight * 0.8);
+      this.waveformCtx.lineTo(x, y);
+    }
+    
+    this.waveformCtx.closePath();
+    this.waveformCtx.fillStyle = 'rgba(94, 75, 182, 0.3)';
+    this.waveformCtx.fill();
+    this.waveformCtx.stroke();
+  }
+
+  resizeWaveform() {
+    if (!this.waveformCanvas) return;
+    
+    const rect = this.waveformCanvas.getBoundingClientRect();
+    this.waveformCanvas.width = rect.width * window.devicePixelRatio;
+    this.waveformCanvas.height = rect.height * window.devicePixelRatio;
+    this.waveformCtx.scale(window.devicePixelRatio, window.devicePixelRatio);
+    
+    if (this.waveformData) {
+      this.generateWaveform();
+    }
+  }
+
+  handleWaveformClick(e) {
+    if (!this.audioBuffer) return;
+    
+    const rect = this.waveformCanvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const percent = x / rect.width;
+    const time = percent * this.duration;
+    
+    this.pauseTime = time;
+    
+    if (this.isPlaying) {
+      this.pause();
+      this.play();
+    }
+  }
+
+  updateLoopRegion() {
+    if (!this.waveformLoopRegion || !this.waveformCanvas) return;
+    
+    const width = this.waveformCanvas.getBoundingClientRect().width;
+    const startPercent = this.loopStart / this.duration;
+    const endPercent = this.loopEnd / this.duration;
+    
+    this.waveformLoopRegion.style.left = (startPercent * width) + 'px';
+    this.waveformLoopRegion.style.width = ((endPercent - startPercent) * width) + 'px';
+    this.waveformLoopRegion.classList.add('active');
+  }
+
+  // Visualizer methods
+  initializeVisualizer() {
+    this.visualizerCanvas = document.getElementById('visualizerCanvas');
+    if (!this.visualizerCanvas) return;
+    
+    this.visualizerCtx = this.visualizerCanvas.getContext('2d');
+    this.resizeVisualizer();
+    
+    // Initialize particles
+    this.createParticles();
+    
+    // Handle window resize
+    window.addEventListener('resize', () => this.resizeVisualizer());
+  }
+
+  resizeVisualizer() {
+    if (!this.visualizerCanvas) return;
+    
+    this.visualizerCanvas.width = window.innerWidth;
+    this.visualizerCanvas.height = window.innerHeight;
+  }
+
+  createParticles() {
+    const particleCount = 50;
+    this.particles = [];
+    
+    for (let i = 0; i < particleCount; i++) {
+      this.particles.push({
+        x: Math.random() * window.innerWidth,
+        y: Math.random() * window.innerHeight,
+        vx: (Math.random() - 0.5) * 0.5,
+        vy: (Math.random() - 0.5) * 0.5,
+        size: Math.random() * 2 + 1,
+        hue: Math.random() * 60 + 260, // Purple to red range
+        brightness: 50
+      });
+    }
+  }
+
+  startVisualizer() {
+    if (!this.visualizerCtx || this.animationId) return;
+    
+    const animate = () => {
+      this.animationId = requestAnimationFrame(animate);
+      this.drawVisualizer();
+    };
+    
+    animate();
+  }
+
+  stopVisualizer() {
+    if (this.animationId) {
+      cancelAnimationFrame(this.animationId);
+      this.animationId = null;
+    }
+    
+    // Clear canvas
+    if (this.visualizerCtx) {
+      this.visualizerCtx.clearRect(0, 0, this.visualizerCanvas.width, this.visualizerCanvas.height);
+    }
+  }
+
+  drawVisualizer() {
+    if (!this.visualizerCtx || !this.analyserNode) return;
+    
+    const width = this.visualizerCanvas.width;
+    const height = this.visualizerCanvas.height;
+    
+    // Get frequency data
+    this.analyserNode.getByteFrequencyData(this.frequencyData);
+    
+    // Calculate average frequency for reactive effects
+    let average = 0;
+    for (let i = 0; i < this.bufferLength; i++) {
+      average += this.frequencyData[i];
+    }
+    average = average / this.bufferLength;
+    
+    // Clear with fade effect
+    this.visualizerCtx.fillStyle = 'rgba(15, 15, 35, 0.1)';
+    this.visualizerCtx.fillRect(0, 0, width, height);
+    
+    // Draw frequency bars
+    const barWidth = width / this.bufferLength * 2.5;
+    let x = 0;
+    
+    for (let i = 0; i < this.bufferLength; i++) {
+      const barHeight = (this.frequencyData[i] / 255) * height * 0.7;
+      
+      // Apply volume scaling
+      const volumeScale = this.gainNode ? this.gainNode.gain.value : 1;
+      const scaledHeight = barHeight * volumeScale;
+      
+      // Create gradient for bars
+      const gradient = this.visualizerCtx.createLinearGradient(0, height - scaledHeight, 0, height);
+      gradient.addColorStop(0, `hsla(${280 - i * 0.5}, 70%, 60%, 0.8)`);
+      gradient.addColorStop(1, `hsla(${280 - i * 0.5}, 70%, 40%, 0.3)`);
+      
+      this.visualizerCtx.fillStyle = gradient;
+      this.visualizerCtx.fillRect(x, height - scaledHeight, barWidth - 2, scaledHeight);
+      
+      // Mirror effect
+      this.visualizerCtx.fillStyle = `hsla(${280 - i * 0.5}, 70%, 50%, 0.1)`;
+      this.visualizerCtx.fillRect(x, 0, barWidth - 2, scaledHeight * 0.3);
+      
+      x += barWidth;
+    }
+    
+    // Update and draw particles
+    this.particles.forEach(particle => {
+      // Update position
+      particle.x += particle.vx * (1 + average / 100);
+      particle.y += particle.vy * (1 + average / 100);
+      
+      // Wrap around edges
+      if (particle.x < 0) particle.x = width;
+      if (particle.x > width) particle.x = 0;
+      if (particle.y < 0) particle.y = height;
+      if (particle.y > height) particle.y = 0;
+      
+      // Update brightness based on audio
+      particle.brightness = 50 + (average / 255) * 50;
+      
+      // Draw particle
+      this.visualizerCtx.beginPath();
+      this.visualizerCtx.arc(particle.x, particle.y, particle.size * (1 + average / 200), 0, Math.PI * 2);
+      this.visualizerCtx.fillStyle = `hsla(${particle.hue}, 70%, ${particle.brightness}%, 0.5)`;
+      this.visualizerCtx.fill();
+      
+      // Add glow effect
+      this.visualizerCtx.shadowBlur = 20;
+      this.visualizerCtx.shadowColor = `hsla(${particle.hue}, 70%, ${particle.brightness}%, 0.3)`;
+      this.visualizerCtx.fill();
+      this.visualizerCtx.shadowBlur = 0;
+    });
   }
 }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,6 +18,9 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/15.7.1/nouislider.min.css" />
   </head>
   <body>
+    <!-- Audio Visualizer Background -->
+    <canvas id="visualizerCanvas" class="visualizer-canvas"></canvas>
+    
     <div class="app-container">
       <!-- Header -->
       <header class="app-header">
@@ -85,6 +88,15 @@
           <div class="progress-container">
             <div class="progress-bar" id="progressBar">
               <div class="progress-fill" id="progressFill"></div>
+            </div>
+          </div>
+
+          <!-- Waveform Visualization -->
+          <div class="waveform-container">
+            <canvas id="waveformCanvas" class="waveform-canvas"></canvas>
+            <div class="waveform-overlay">
+              <div class="waveform-playhead" id="waveformPlayhead"></div>
+              <div class="waveform-loop-region" id="waveformLoopRegion"></div>
             </div>
           </div>
 
@@ -168,14 +180,22 @@
   body {
     font-family: system-ui, -apple-system, sans-serif;
     background: var(--color-bg);
-    background-image: 
-      radial-gradient(circle at 20% 80%, rgba(94, 75, 182, 0.3) 0%, transparent 50%),
-      radial-gradient(circle at 80% 20%, rgba(231, 76, 60, 0.3) 0%, transparent 50%),
-      radial-gradient(circle at 40% 40%, rgba(94, 75, 182, 0.2) 0%, transparent 50%);
     color: var(--color-text);
     min-height: 100vh;
     display: flex;
     flex-direction: column;
+    overflow-x: hidden;
+  }
+
+  /* Audio Visualizer Canvas */
+  .visualizer-canvas {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    opacity: 0.8;
   }
 
   .app-container {
@@ -472,6 +492,65 @@
   .loop-reset-btn:hover {
     background: var(--color-surface-hover);
     border-color: rgba(255, 255, 255, 0.3);
+  }
+
+  /* Waveform Visualization */
+  .waveform-container {
+    position: relative;
+    height: 120px;
+    margin: 1.5rem 0;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius);
+    overflow: hidden;
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .waveform-canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+    cursor: pointer;
+  }
+
+  .waveform-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  .waveform-playhead {
+    position: absolute;
+    top: 0;
+    width: 2px;
+    height: 100%;
+    background: var(--color-primary);
+    box-shadow: 0 0 8px var(--color-primary);
+    transform: translateX(-50%);
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .waveform-playhead.active {
+    opacity: 1;
+  }
+
+  .waveform-loop-region {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    background: rgba(94, 75, 182, 0.2);
+    border-left: 2px solid var(--color-primary);
+    border-right: 2px solid var(--color-primary);
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .waveform-loop-region.active {
+    opacity: 1;
   }
 
   .app-footer {


### PR DESCRIPTION
- 背景に全画面キャンバスを追加し、音楽と同期するビジュアライザーを表示
- Web Audio APIのAnalyserNodeを使用してリアルタイム周波数解析を実装
- 周波数バーとパーティクルエフェクトによる視覚効果を追加
  - グラデーション付き周波数バー（紫〜赤のテーマカラー）
  - 音楽の強度に反応して動くパーティクル
  - ミラーエフェクトとグロー効果
- 再生/一時停止、音量調整と連動した制御を実装
- requestAnimationFrameによる60fps描画とパフォーマンス最適化