### PR TITLE
feat: 再生/一時停止アイコン切り替えとライセンス情報表示機能を追加

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,8 +31,8 @@ import '../scripts/app.js';
         <h1>Cadenzio</h1>
         <button class="settings-btn" aria-label="設定">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"></path>
             <circle cx="12" cy="12" r="3"></circle>
-            <path d="M12 1v6m0 6v6m9-9h-6m-6 0H3m16.2-7.2l-4.2 4.2m-6 6l-4.2 4.2m0-10.4l4.2 4.2m6 6l4.2 4.2"></path>
           </svg>
         </button>
       </header>
@@ -53,21 +53,23 @@ import '../scripts/app.js';
               または<button class="file-select-btn" type="button">ファイルを選択</button>
             </p>
           </div>
-          <div class="file-info" id="fileInfo" hidden>
-            <p class="file-name" id="fileName"></p>
-            <button class="file-clear-btn" type="button" aria-label="ファイルをクリア">×</button>
-          </div>
         </section>
 
         <!-- Player Controls -->
         <section class="player-section" id="playerSection" hidden>
+          <!-- File Info -->
+          <div class="file-info" id="fileInfo">
+            <p class="file-name" id="fileName"></p>
+            <button class="file-clear-btn" type="button" aria-label="ファイルをクリア">×</button>
+          </div>
+
           <!-- Play Controls -->
           <div class="player-controls">
             <button class="play-btn" id="playBtn" aria-label="再生">
               <svg class="play-icon" width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M8 5v14l11-7z"></path>
               </svg>
-              <svg class="pause-icon" hidden width="32" height="32" viewBox="0 0 24 24" fill="currentColor">
+              <svg class="pause-icon" width="32" height="32" viewBox="0 0 24 24" fill="currentColor" hidden>
                 <rect x="6" y="4" width="4" height="16"></rect>
                 <rect x="14" y="4" width="4" height="16"></rect>
               </svg>
@@ -128,6 +130,39 @@ import '../scripts/app.js';
     <!-- Error Toast -->
     <div class="error-toast" id="errorToast" role="alert" aria-live="polite" hidden>
       <p class="error-message" id="errorMessage"></p>
+    </div>
+
+    <!-- License Modal -->
+    <div class="modal-overlay" id="licenseModal" hidden>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>ライセンス情報</h2>
+          <button class="modal-close-btn" id="licenseModalClose" aria-label="閉じる">&times;</button>
+        </div>
+        <div class="modal-body">
+          <div class="license-info">
+            <h3>Dependencies</h3>
+            <div class="license-item">
+              <h4>Astro</h4>
+              <p><strong>Version:</strong> 5.9.3</p>
+              <p><strong>License:</strong> MIT</p>
+              <p><strong>Repository:</strong> <a href="https://github.com/withastro/astro" target="_blank" rel="noopener">https://github.com/withastro/astro</a></p>
+            </div>
+            <div class="license-item">
+              <h4>noUiSlider</h4>
+              <p><strong>Version:</strong> 15.8.1</p>
+              <p><strong>License:</strong> MIT</p>
+              <p><strong>Repository:</strong> <a href="https://github.com/leongersen/noUiSlider" target="_blank" rel="noopener">https://github.com/leongersen/noUiSlider</a></p>
+            </div>
+            <div class="license-item">
+              <h4>Cadenzio</h4>
+              <p><strong>Version:</strong> 0.0.1</p>
+              <p><strong>License:</strong> MIT</p>
+              <p><strong>Description:</strong> 音楽ループプレイヤー</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     

--- a/src/scripts/AudioEngine.js
+++ b/src/scripts/AudioEngine.js
@@ -69,8 +69,18 @@ class AudioEngine {
   /**
    * Start audio playback with current loop settings
    */
-  play() {
+  async play() {
     if (!this.audioBuffer) return;
+    
+    // Ensure audio context is initialized
+    if (!this.audioContext) {
+      await this.initialize();
+    }
+    
+    // Resume context if suspended
+    if (this.audioContext.state === 'suspended') {
+      await this.audioContext.resume();
+    }
     
     this.sourceNode = this.audioContext.createBufferSource();
     this.sourceNode.buffer = this.audioBuffer;

--- a/src/scripts/UIController.js
+++ b/src/scripts/UIController.js
@@ -48,6 +48,11 @@ class UIController {
     // Error elements
     this.elements.errorToast = document.getElementById('errorToast');
     this.elements.errorMessage = document.getElementById('errorMessage');
+    
+    // Modal elements
+    this.elements.settingsBtn = document.querySelector('.settings-btn');
+    this.elements.licenseModal = document.getElementById('licenseModal');
+    this.elements.licenseModalClose = document.getElementById('licenseModalClose');
   }
 
   initializeEventListeners() {
@@ -61,6 +66,28 @@ class UIController {
     this.elements.dropZone.addEventListener('click', () => {
       this.elements.fileInput.click();
     });
+    
+    // License modal
+    this.elements.settingsBtn.addEventListener('click', () => {
+      this.showLicenseModal();
+    });
+    
+    this.elements.licenseModalClose.addEventListener('click', () => {
+      this.hideLicenseModal();
+    });
+    
+    this.elements.licenseModal.addEventListener('click', (e) => {
+      if (e.target === this.elements.licenseModal) {
+        this.hideLicenseModal();
+      }
+    });
+    
+    // Escape key to close modal
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !this.elements.licenseModal.hidden) {
+        this.hideLicenseModal();
+      }
+    });
   }
 
   // File UI methods
@@ -68,16 +95,6 @@ class UIController {
     if (this.elements.fileName) {
       this.elements.fileName.textContent = name;
     }
-  }
-
-  showFileInfo() {
-    if (this.elements.dropZone) this.elements.dropZone.hidden = true;
-    if (this.elements.fileInfo) this.elements.fileInfo.hidden = false;
-  }
-
-  hideFileInfo() {
-    if (this.elements.dropZone) this.elements.dropZone.hidden = false;
-    if (this.elements.fileInfo) this.elements.fileInfo.hidden = true;
   }
 
   clearFileInput() {
@@ -103,6 +120,47 @@ class UIController {
     if (this.elements.playIcon && this.elements.pauseIcon) {
       this.elements.playIcon.hidden = isPlaying;
       this.elements.pauseIcon.hidden = !isPlaying;
+      
+      // Force style update with multiple methods
+      if (isPlaying) {
+        // Hide play icon, show pause icon
+        this.elements.playIcon.style.display = 'none';
+        this.elements.playIcon.style.visibility = 'hidden';
+        this.elements.playIcon.style.opacity = '0';
+        this.elements.playIcon.setAttribute('hidden', 'true');
+        
+        this.elements.pauseIcon.style.display = 'block';
+        this.elements.pauseIcon.style.visibility = 'visible';
+        this.elements.pauseIcon.style.opacity = '1';
+        this.elements.pauseIcon.removeAttribute('hidden');
+      } else {
+        // Show play icon, hide pause icon
+        this.elements.playIcon.style.display = 'block';
+        this.elements.playIcon.style.visibility = 'visible';
+        this.elements.playIcon.style.opacity = '1';
+        this.elements.playIcon.removeAttribute('hidden');
+        
+        this.elements.pauseIcon.style.display = 'none';
+        this.elements.pauseIcon.style.visibility = 'hidden';
+        this.elements.pauseIcon.style.opacity = '0';
+        this.elements.pauseIcon.setAttribute('hidden', 'true');
+      }
+    }
+    if (this.elements.playBtn) {
+      this.elements.playBtn.setAttribute('aria-label', isPlaying ? '一時停止' : '再生');
+    }
+  }
+  
+  // License modal methods
+  showLicenseModal() {
+    if (this.elements.licenseModal) {
+      this.elements.licenseModal.hidden = false;
+    }
+  }
+  
+  hideLicenseModal() {
+    if (this.elements.licenseModal) {
+      this.elements.licenseModal.hidden = true;
     }
   }
 

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -120,7 +120,6 @@ class CadenzioApp {
       
       // Update UI
       this.ui.setFileName(file.name);
-      this.ui.showFileInfo();
       this.ui.showPlayer();
       this.ui.updateDuration(formatTime(this.audioEngine.duration));
       
@@ -172,7 +171,6 @@ class CadenzioApp {
     this.audioVisualizer.stop();
     this.fileManager.clearFile();
     
-    this.ui.hideFileInfo();
     this.ui.hidePlayer();
     this.ui.clearFileInput();
     this.ui.updatePlayButton(false);
@@ -216,8 +214,8 @@ class CadenzioApp {
   /**
    * Start playback
    */
-  play() {
-    this.audioEngine.play();
+  async play() {
+    await this.audioEngine.play();
     this.ui.updatePlayButton(true);
     this.audioVisualizer.start(this.audioEngine);
   }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -8,6 +8,32 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
+/* Force hide for play/pause icons */
+.play-icon[hidden],
+.pause-icon[hidden] {
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+}
+
+/* Force show for visible play/pause icons - only when not explicitly hidden */
+.play-icon:not([hidden]):not([style*="display: none"]),
+.pause-icon:not([hidden]):not([style*="display: none"]) {
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+}
+
+/* Override for explicitly hidden icons */
+.play-icon[style*="display: none"],
+.pause-icon[style*="display: none"] {
+  display: none !important;
+}
+
 :root {
   --color-primary: #5e4bb6;
   --color-primary-dark: #4a3c91;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -56,36 +56,35 @@
 }
 
 .file-info {
-  background: var(--color-glass);
-  backdrop-filter: blur(var(--blur));
-  -webkit-backdrop-filter: blur(var(--blur));
-  border: 1px solid var(--color-glass-border);
-  padding: 1rem;
-  border-radius: var(--radius);
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
+  gap: 1rem;
   margin-top: 1rem;
-  box-shadow: var(--shadow-glass);
+}
+
+.file-name {
+  color: var(--color-text-dim);
+  font-size: 0.875rem;
 }
 
 .file-clear-btn {
   background: none;
   border: none;
   color: var(--color-text-dim);
-  font-size: 1.5rem;
+  font-size: 1.2rem;
   cursor: pointer;
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 50%;
   transition: all 0.2s;
+  opacity: 0.7;
 }
 
 .file-clear-btn:hover {
-  background: var(--color-surface-hover);
+  opacity: 1;
   color: var(--color-text);
 }
 
@@ -105,11 +104,127 @@
   animation: slideIn 0.3s ease-out;
 }
 
+/* License Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.modal-content {
+  background: var(--color-glass);
+  backdrop-filter: blur(var(--blur));
+  -webkit-backdrop-filter: blur(var(--blur));
+  border: 1px solid var(--color-glass-border);
+  border-radius: var(--radius);
+  max-width: 600px;
+  max-height: 80vh;
+  width: 90%;
+  box-shadow: var(--shadow-glass);
+  overflow: hidden;
+}
+
+.modal-header {
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--color-glass-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modal-header h2 {
+  color: var(--color-text);
+  font-size: 1.5rem;
+  margin: 0;
+}
+
+.modal-close-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-dim);
+  font-size: 2rem;
+  cursor: pointer;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s;
+}
+
+.modal-close-btn:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.modal-body {
+  padding: 1.5rem;
+  overflow-y: auto;
+  max-height: calc(80vh - 100px);
+}
+
+.license-info h3 {
+  color: var(--color-text);
+  margin-bottom: 1rem;
+  font-size: 1.25rem;
+}
+
+.license-item {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.license-item h4 {
+  color: var(--color-primary);
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+}
+
+.license-item p {
+  color: var(--color-text-dim);
+  margin-bottom: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.license-item a {
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.license-item a:hover {
+  color: var(--color-primary-dark);
+  text-decoration: underline;
+}
+
 @keyframes slideIn {
   from {
     transform: translateX(100%);
   }
   to {
     transform: translateX(0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }

--- a/src/styles/player.css
+++ b/src/styles/player.css
@@ -42,6 +42,20 @@
   box-shadow: 0 6px 20px rgba(94, 75, 182, 0.5);
 }
 
+.play-icon,
+.pause-icon {
+  position: absolute;
+  pointer-events: none;
+}
+
+.play-icon {
+  color: #ffffff;
+}
+
+.pause-icon {
+  color: #ffffff;
+}
+
 .time-display {
   font-variant-numeric: tabular-nums;
   color: var(--color-text-dim);


### PR DESCRIPTION
- 再生ボタンのアイコン切り替え問題を修正（hidden属性とCSSの競合解決）
- 設定ボタンをより直感的な歯車アイコンに変更
- ライセンス情報表示モーダルを実装（Astro、noUiSlider、Cadenzioの情報）
- ファイル情報表示をプレイヤーセクション内に移動して表示タイミングを統一
- AudioContextの初期化とsuspended状態の自動復旧機能を追加